### PR TITLE
showing all lanes on process view zoom out

### DIFF
--- a/src/app/SBE/lane/index.js
+++ b/src/app/SBE/lane/index.js
@@ -7,7 +7,7 @@ import Footer from './Footer'
 import './lane.css'
 import Card from 'app/layouts/components/card'
 
-const Lane = ({ sbeCode, dashboard }) => {
+const Lane = ({ sbeCode, dashboard, width }) => {
   const rows = useSelector(selectRows(sbeCode), (prev, next) => prev.length === next.length)
 
   if (dashboard && !rows.length) return null
@@ -16,6 +16,7 @@ const Lane = ({ sbeCode, dashboard }) => {
     <Card
       variant="card0"
       p={[2, 2, 2, 3]}
+      width={width}
       maxH="78vh"
       className="nobar"
       h="full"

--- a/src/app/SBE/lane/index.js
+++ b/src/app/SBE/lane/index.js
@@ -7,7 +7,7 @@ import Footer from './Footer'
 import './lane.css'
 import Card from 'app/layouts/components/card'
 
-const Lane = ({ sbeCode, dashboard, width }) => {
+const Lane = ({ sbeCode, dashboard }) => {
   const rows = useSelector(selectRows(sbeCode), (prev, next) => prev.length === next.length)
 
   if (dashboard && !rows.length) return null
@@ -16,12 +16,11 @@ const Lane = ({ sbeCode, dashboard, width }) => {
     <Card
       variant="card0"
       p={[2, 2, 2, 3]}
-      width={width}
       maxH="78vh"
       className="nobar"
       h="full"
       overflowY="scroll"
-      minW="15vw"
+      minW="14vw"
     >
       <VStack>
         <Title sbeCode={sbeCode} />

--- a/src/app/layouts/dashboard/intern/index.js
+++ b/src/app/layouts/dashboard/intern/index.js
@@ -12,7 +12,6 @@ import Recommendations from './recommendations'
 import Attribute from 'app/BE/attribute'
 import { useEffect } from 'react'
 import Card from 'app/layouts/components/card'
-import Progress from './progress'
 
 const Intern = ({ userCode }) => {
   const [name, occ, status] = useSelector(


### PR DESCRIPTION
After trying a bunch of css combinations, I think this works the best. 

on 50% zoom level
<img width="1440" alt="Screen Shot 2021-06-28 at 11 01 41 am" src="https://user-images.githubusercontent.com/42728641/123565516-b1119b80-d7ac-11eb-898d-de324c864c40.png">

on 75% zoom level
<img width="1440" alt="Screen Shot 2021-06-28 at 11 05 29 am" src="https://user-images.githubusercontent.com/42728641/123565584-f0d88300-d7ac-11eb-90a3-b156e56ede7c.png">
