### PR TITLE
make attribute extensible

### DIFF
--- a/src/redux/db/utils/format.ts
+++ b/src/redux/db/utils/format.ts
@@ -40,6 +40,8 @@ export const formatBaseEntity = (
       const valueKey = compose(find(includes('value')), keys)(attribute) as string
 
       attribute = { value: attribute[valueKey], ...attribute }
+    } else {
+      attribute = { ...attribute }
     }
     attribute.created = ''
 


### PR DESCRIPTION
With new search results, some attributes are not extensible and this is causing an error "Object is not extensible" when updating the created field.