### PR TITLE
Update Items.js

### DIFF
--- a/src/app/DTT/select/Items.js
+++ b/src/app/DTT/select/Items.js
@@ -47,7 +47,7 @@ const ItemsForAutocomplete = ({
     ref,
     handler: () => !isMobile && setOpen(false),
   })
-  const maxW = useMobileValue(['', '25vw'])
+  const maxW = '100%'; //useMobileValue(['', '25vw'])
   return (
     <Card
       overflow="hidden"


### PR DESCRIPTION
If we set maxW to useMobileValue, this cause the width of items not to match the select width when we use desktop. useMobileValue only works if we use a mobile device. But if we set the maxW to 100%, than it becomes responsive and the width of select and select items is the same. on all devices.