### PR TITLE
Gen-744 IM - HCR View/ Agent View - Agreement docs - Signed date doesn't visible in a one line(Fixed)

### DIFF
--- a/src/app/DTT/date/index.js
+++ b/src/app/DTT/date/index.js
@@ -28,7 +28,7 @@ const Read = ({ data, typeName, config }) => {
 
   if (date === 'Invalid Date') return null
   return (
-    <Text minW="4rem" {...config}>
+    <Text minW="10rem" {...config}>
       {date}
     </Text>
   )
@@ -46,9 +46,9 @@ const Write = ({ questionCode, data, onSendAnswer, typeName, regexPattern, quest
   const onlyYear = typeName === 'year'
 
   const handleChange = e => {
-    if(e.target.value){
-    !errorStatus && onSendAnswer(safelyParseDate(e.target.value).toISOString())
-    dispatchFieldMessage({ payload: questionCode })
+    if (e.target.value) {
+      !errorStatus && onSendAnswer(safelyParseDate(e.target.value).toISOString())
+      dispatchFieldMessage({ payload: questionCode })
     }
   }
 

--- a/src/app/DTT/select/Items.js
+++ b/src/app/DTT/select/Items.js
@@ -47,7 +47,7 @@ const ItemsForAutocomplete = ({
     ref,
     handler: () => !isMobile && setOpen(false),
   })
-  const maxW = useMobileValue(['', '25vw'])
+  const maxW = '100%' //useMobileValue(['', '25vw'])
   return (
     <Card
       overflow="hidden"


### PR DESCRIPTION
From  <Text **minW="4rem**" {...config}> {date} </Text> to <Text **minW="10rem**" {...config}> {date} </Text>. if we use "4rem" this causes the display of date to be in two separate lines, but if we change it to 10rem this causes the display of date to be on one single line.