### PR TITLE
Mentor match, Agree to mentor Group form, alignment.

### DIFF
--- a/src/app/ASKS/form/desktop_view/index.js
+++ b/src/app/ASKS/form/desktop_view/index.js
@@ -11,7 +11,7 @@ const FormDesktopView = ({ title, onFinish, questionCode, childAsks, config = {}
   if (!groups.length)
     return (
       <Center>
-        <Card w="50%" maxW={'75rem'} shadow={'md'}>
+        <Card w={title === 'Agent'? '50%':'full'} maxW={'75rem'} shadow={'md'}>
           <VStack align="start" spacing={8}>
             <Text textStyle="head.2">{title}</Text>
             {config?.subHeader && <Text textStyle="body.3">{config.subHeader}</Text>}


### PR DESCRIPTION
When you log as an agent on Intern match and than click the plus button on the header  to add another agent,
the form that is used to enter agent details uses the same card as the one on mentor match for Agree to mentor Group.

So  on intern match the card is displayed nicely on width = 50%,  but the one on mentor match it is displayed nicely when Width = full
So i create a ternary operator to decide the width for the card  on mentor match and intern match.