### PR TITLE
Changing button label 

### DIFF
--- a/src/app/layouts/dashboard/mentee/helpers/get-timeline-items.js
+++ b/src/app/layouts/dashboard/mentee/helpers/get-timeline-items.js
@@ -51,7 +51,7 @@ const useGetMenteeTimelineItems = () => {
       invitationStatus: menteeStatus,
     },
     {
-      title: 'Introductory Meeting with Mentor',
+      title: 'Meet & Greet',
       description: 'Select one of the dates proposed by your potential mentor',
       buttonText: 'Meet & Greet',
       completed: isPendingSelectDate ? 'INCOMPLETE' : 'COMPLETE' && selectMentorStatus,


### PR DESCRIPTION
Mentee - timeline on left shows wrong button - “introductory meeting with mentor” - button should say “Meet & Greet”