### PR TITLE
Alias code now always shows instead of name

### DIFF
--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -54,9 +54,7 @@ const prettyLog = (msg, data = {}, style) => {
   const showConsoleLogs = showLogs()
 
   const title = data.items
-    ? data.items.length === 1
-      ? data.items[0]?.name
-      : data.parentCode && data.questionCode
+    ? data.parentCode && data.questionCode
       ? `Rows - ${data.parentCode} - ${data.questionCode}`
       : data.parentCode
       ? `Rows - ${data.parentCode} `


### PR DESCRIPTION
Requested by Jasper/Myself,
Now the logs will prioritize showing alias codes as the title of messages,
to make the logs clearer to read
![image](https://user-images.githubusercontent.com/13941914/176104695-697c951f-5e67-4914-8ed1-33e1e9837f9b.png)
