### PR TITLE
PIM-64 relocate video download button

### DIFF
--- a/src/app/DTT/video/Player.tsx
+++ b/src/app/DTT/video/Player.tsx
@@ -3,7 +3,7 @@ import { ReactElement } from 'react'
 const Player = ({ src }: { src: string }): ReactElement => {
   return (
     <video
-      style={{ maxHeight: '340px', minWidth: '340px' }}
+      style={{ maxHeight: '340px', minWidth: '240px' }}
       controls
       autoPlay
       muted

--- a/src/app/DTT/video/index.js
+++ b/src/app/DTT/video/index.js
@@ -193,10 +193,10 @@ const Read = ({ data, mini, styles, config = {} }) => {
       </PopoverContent>
     </Popover>
   ) : (
-    <Box>
+    <HStack sx={{ alignItems: 'flex-end' }}>
       <Player src={src} inline={config.inline} styles={styles} />
       {hasDownloadableRole && <Download urlLink={downloadableLink} />}
-    </Box>
+    </HStack>
   )
 }
 


### PR DESCRIPTION
Move video download button to the right of the video.
<img width="392" alt="Screen Shot 2022-07-22 at 9 49 36 am" src="https://user-images.githubusercontent.com/108104906/180333293-0f0d29b9-a2cb-417b-af44-acfc7af0c6a4.png">

