### PR TITLE
Neatened up the default detail view template

### DIFF
--- a/src/app/PCM/templates/tpl-detail-view/detail-field.js
+++ b/src/app/PCM/templates/tpl-detail-view/detail-field.js
@@ -14,7 +14,7 @@ const DetailField = ({ sbeCode, code, attributeCode, isTitle, actions }) => {
   const title = entityAttribute?.attribute?.name || attributeCode
   const size = isTitle ? '2xl' : 'md'
   const weight = isTitle ? '700' : 'normal'
-  const label = isTitle || contains('_IMAGE')(attributeCode) ? '' : <Text>{title}</Text>
+  const label = isTitle || contains('_IMAGE_')(attributeCode) ? '' : <Text>{title}</Text>
 
   const acts =
     isTitle && actions?.length > 0 ? (

--- a/src/app/PCM/templates/tpl-detail-view/detail-field.js
+++ b/src/app/PCM/templates/tpl-detail-view/detail-field.js
@@ -1,23 +1,23 @@
-import { Box, Text } from '@chakra-ui/react'
+import { Box, Text, HStack } from '@chakra-ui/react'
 
 import Attribute from 'app/BE/attribute'
 import ContextMenu from 'app/BE/context'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { equals } from 'ramda'
+import { contains } from 'ramda'
 import { faEllipsisV } from '@fortawesome/free-solid-svg-icons'
 import { selectCode } from 'redux/db/selectors'
 import { useSelector } from 'react-redux'
 
-const DetailField = ({ sbeCode, code, attributeCode, index, actions }) => {
+const DetailField = ({ sbeCode, code, attributeCode, isTitle, actions }) => {
   const entityAttribute = useSelector(selectCode(code, attributeCode))
 
   const title = entityAttribute?.attribute?.name || attributeCode
-  const size = equals(index)(0) ? '2xl' : 'md'
-  const weight = equals(index)(0) ? '700' : 'normal'
-  const label = equals(index)(0) ? '' : <Text>{title}:</Text>
+  const size = isTitle ? '2xl' : 'md'
+  const weight = isTitle ? '700' : 'normal'
+  const label = isTitle || contains('_IMAGE')(attributeCode) ? '' : <Text>{title}</Text>
 
   const acts =
-    equals(index)(0) && actions?.length > 0 ? (
+    isTitle && actions?.length > 0 ? (
       <ContextMenu
         actions={actions}
         parentCode={sbeCode}
@@ -29,17 +29,19 @@ const DetailField = ({ sbeCode, code, attributeCode, index, actions }) => {
     )
 
   return (
-    <Box>
+    <HStack>
       {acts}
-      <Text as="label" hidden>
-        {label}
-      </Text>
-      <Attribute
-        code={code}
-        attribute={attributeCode}
-        config={{ fontSize: size, fontWeight: weight }}
-      />
-    </Box>
+      <Box>
+        <Text as="label" textStyle="tail.1" color="gray.700">
+          {label}
+        </Text>
+        <Attribute
+          code={code}
+          attribute={attributeCode}
+          config={{ fontSize: size, fontWeight: weight }}
+        />
+      </Box>
+    </HStack>
   )
 }
 

--- a/src/app/PCM/templates/tpl-detail-view/index.js
+++ b/src/app/PCM/templates/tpl-detail-view/index.js
@@ -17,6 +17,7 @@ const TemplateDetailView = ({ mappedPcm, depth }) => {
     map(act => act?.attributeCode)(useGetActionsFromCode(sbeCode) || []),
   )
 
+  //This is not a good way to check this but it was the best I could come up with short term
   const titleIndex = findIndex(notIncludes('_IMAGE_'))(mappedValues)
 
   return (

--- a/src/app/PCM/templates/tpl-detail-view/index.js
+++ b/src/app/PCM/templates/tpl-detail-view/index.js
@@ -1,9 +1,10 @@
-import { Box } from '@chakra-ui/react'
+import { VStack } from '@chakra-ui/react'
 import useGetMappedBaseEntity from 'app/PCM/helpers/use-get-mapped-base-entity'
 import { useGetActionsFromCode } from 'app/SBE/utils/get-actions'
-import { filter, map } from 'ramda'
+import { filter, findIndex, map } from 'ramda'
 import DetailField from './detail-field'
 import { getFields, getColumnDefs } from '../../helpers/sbe-utils'
+import notIncludes from 'utils/helpers/not-includes'
 
 const TemplateDetailView = ({ mappedPcm, depth }) => {
   const sbeCode = mappedPcm.PRI_LOC1
@@ -16,8 +17,10 @@ const TemplateDetailView = ({ mappedPcm, depth }) => {
     map(act => act?.attributeCode)(useGetActionsFromCode(sbeCode) || []),
   )
 
+  const titleIndex = findIndex(notIncludes('_IMAGE_'))(mappedValues)
+
   return (
-    <Box padding={'10px'}>
+    <VStack padding={'10px'} align="start">
       {mappedValues.map((attributeCode, index) => {
         return (
           <DetailField
@@ -25,12 +28,12 @@ const TemplateDetailView = ({ mappedPcm, depth }) => {
             sbeCode={sbeCode}
             code={baseEntityCode}
             attributeCode={attributeCode}
-            index={index}
+            isTitle={titleIndex === index}
             actions={actions}
           />
         )
       })}
-    </Box>
+    </VStack>
   )
 }
 

--- a/src/utils/helpers/not-includes.js
+++ b/src/utils/helpers/not-includes.js
@@ -1,0 +1,5 @@
+import { compose, includes, not } from 'ramda'
+
+const notIncludes = x => compose(not, includes(x))
+
+export default notIncludes


### PR DESCRIPTION
It wasn't quite behaving well with images or anything like that, so I've neatened it for the short term.
This is meant to be the generic template even though I'm demoing it here with a property
![image](https://user-images.githubusercontent.com/13941914/190950437-631c3f85-9bc8-48c9-b406-2b0664c7a45a.png)
