### PR TITLE
Fixed up errors with template handler, fixed showLogs, showVerbose and showTemplateNames

### DIFF
--- a/src/app/PCM/templates/index.js
+++ b/src/app/PCM/templates/index.js
@@ -25,6 +25,8 @@ import TemplateWest from 'app/PCM/templates/sidebar/tpl-west'
 import debugOut from 'utils/debug-out'
 import hasNot from 'utils/helpers/has-not.js'
 import TemplateDetailView from './tpl-detail-view'
+import showTemplateNames from 'utils/helpers/show-template-names'
+import { Box, Text } from '@chakra-ui/react'
 
 /**
  * Takes in a mappedPcm, a templateCode and some misc properties and returns a template component.
@@ -74,12 +76,28 @@ const templateHandlerMachine = mappedPcm => templateCode => properties => depth 
     ),
   }
 
-  if (hasNot(templateCode)(listOfTemplates)) {
+  const hasNotGotTemplate = hasNot(templateCode)(listOfTemplates)
+
+  if (hasNotGotTemplate) {
     debugOut.warn(`No template exists for code: ${templateCode}! Falling back on default tempalte!`)
-    return <TemplateDefault {...properties} />
   }
 
-  return listOfTemplates[templateCode]
+  const template = hasNotGotTemplate ? (
+    <TemplateDefault {...properties} />
+  ) : (
+    listOfTemplates[templateCode]
+  )
+
+  return showTemplateNames ? (
+    <Box>
+      <Text>
+        {hasNotGotTemplate ? `TPL_DEFAULT (Couldn't find ${templateCode})` : templateCode}
+      </Text>
+      <Box border="solid 2px red">{template}</Box>
+    </Box>
+  ) : (
+    template
+  )
 }
 
 export default templateHandlerMachine

--- a/src/utils/helpers/show-logs.js
+++ b/src/utils/helpers/show-logs.js
@@ -1,3 +1,6 @@
-const showLogs = process.env.NODE_ENV !== 'production' || localStorage.getItem('useDev')
+import { equals } from 'ramda'
+
+const showLogs =
+  process.env.NODE_ENV !== 'production' || equals(localStorage.getItem('useDev'))('true')
 
 export default showLogs

--- a/src/utils/helpers/show-template-names.js
+++ b/src/utils/helpers/show-template-names.js
@@ -1,3 +1,5 @@
-const showTemplateNames = localStorage.getItem('showTemplateNames')
+import { equals } from 'ramda'
+
+const showTemplateNames = equals(localStorage.getItem('showTemplateNames'))('true')
 
 export default showTemplateNames

--- a/src/utils/helpers/show-verbose.js
+++ b/src/utils/helpers/show-verbose.js
@@ -1,3 +1,5 @@
-const showVerbose = localStorage.getItem('verbose')
+import { equals } from 'ramda'
+
+const showVerbose = equals(localStorage.getItem('verbose'))('true')
 
 export default showVerbose


### PR DESCRIPTION
Turns out localStorage always stores as a string, hence why I'm using equals instead of just returning the value.