### PR TITLE
On failed keycloak, reload the page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,12 @@ import getApiConfig from 'config/get-api-config'
 
 LogRocket.init('geop13/internmatch')
 
+const onKeycloakError = error => {
+  if (!!error) {
+    window.location.reload()
+  }
+}
+
 const initialiseApp = async () => {
   try {
     // initLog()
@@ -25,7 +31,11 @@ const initialiseApp = async () => {
         <ChakraProvider theme={theme}>
           <Fonts />
           <ColorModeScript initialColorMode={theme.config.initialColorMode} />
-          <ReactKeycloakProvider authClient={keycloak} LoadingComponent={<Loading />}>
+          <ReactKeycloakProvider
+            authClient={keycloak}
+            LoadingComponent={<Loading />}
+            onEvent={(event, error) => onKeycloakError(error)}
+          >
             <ErrorContextProvider>
               <IsFieldNotEmptyProvider>
                 <App title={title} />


### PR DESCRIPTION
Keycloak returns an error message if the login works but the user is broken in some way.
So this fix means that if the login is successful but returns an error, it reloads the page, which forces alyson to return the user to the login page