### PR TITLE
Checkboxes now require an answer before they count as validated

### DIFF
--- a/src/app/DTT/check_box/index.js
+++ b/src/app/DTT/check_box/index.js
@@ -4,8 +4,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons'
 import { useGetAttributeFromProjectBaseEntity } from 'app/BE/project-be'
 import { useIsFieldNotEmpty } from 'utils/contexts/IsFieldNotEmptyContext'
-import { useState } from 'react'
-import { isNotNullOrUndefinedOrEmpty } from 'utils/helpers/is-null-or-undefined'
 
 const Read = ({ data }) => {
   return (
@@ -21,15 +19,12 @@ const Read = ({ data }) => {
 
 const Write = ({ questionCode, data, onSendAnswer, isRequired, label }) => {
   const { dispatchFieldMessage } = useIsFieldNotEmpty()
+  let answer = data?.value === 'true' ? 'false' : 'true'
 
-  const colorScheme = useGetAttributeFromProjectBaseEntity('PRI_SURFACE_COLOR')?.valueString
-
-  const [checked, setChecked] = useState(data?.value)
+  const colorScheme = useGetAttributeFromProjectBaseEntity('PRI_SECONDARY_COLOR')?.valueString
 
   const toggle = () => {
-    const newValue = data?.value === 'true' ? 'false' : 'true'
-    onSendAnswer(newValue)
-    setChecked(newValue)
+    onSendAnswer(answer)
     dispatchFieldMessage({ payload: questionCode })
   }
 
@@ -40,15 +35,13 @@ const Write = ({ questionCode, data, onSendAnswer, isRequired, label }) => {
         id={questionCode}
         test-id={questionCode}
         colorScheme={colorScheme}
-        isChecked={checked === 'true'}
+        isChecked={data?.value === 'true'}
         onChange={toggle}
       />
       <FormControl onClick={toggle} isRequired={isRequired}>
         <FormLabel cursor="pointer">{label}</FormLabel>
       </FormControl>
-      {isNotNullOrUndefinedOrEmpty(checked) && (
-        <FontAwesomeIcon opacity="0.5" color="green" icon={faCheckCircle} />
-      )}
+      {answer && <FontAwesomeIcon opacity="0.5" color="green" icon={faCheckCircle} />}
     </HStack>
   )
 }

--- a/src/app/DTT/check_box/index.js
+++ b/src/app/DTT/check_box/index.js
@@ -4,6 +4,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons'
 import { useGetAttributeFromProjectBaseEntity } from 'app/BE/project-be'
 import { useIsFieldNotEmpty } from 'utils/contexts/IsFieldNotEmptyContext'
+import { useState } from 'react'
+import { isNotNullOrUndefinedOrEmpty } from 'utils/helpers/is-null-or-undefined'
 
 const Read = ({ data }) => {
   return (
@@ -19,12 +21,15 @@ const Read = ({ data }) => {
 
 const Write = ({ questionCode, data, onSendAnswer, isRequired, label }) => {
   const { dispatchFieldMessage } = useIsFieldNotEmpty()
-  let answer = data?.value === 'true' ? 'false' : 'true'
 
-  const colorScheme = useGetAttributeFromProjectBaseEntity('PRI_COLOR')?.valueString
+  const colorScheme = useGetAttributeFromProjectBaseEntity('PRI_SURFACE_COLOR')?.valueString
+
+  const [checked, setChecked] = useState(data?.value)
 
   const toggle = () => {
-    onSendAnswer(answer)
+    const newValue = data?.value === 'true' ? 'false' : 'true'
+    onSendAnswer(newValue)
+    setChecked(newValue)
     dispatchFieldMessage({ payload: questionCode })
   }
 
@@ -35,13 +40,15 @@ const Write = ({ questionCode, data, onSendAnswer, isRequired, label }) => {
         id={questionCode}
         test-id={questionCode}
         colorScheme={colorScheme}
-        isChecked={data?.value === 'true'}
+        isChecked={checked === 'true'}
         onChange={toggle}
       />
       <FormControl onClick={toggle} isRequired={isRequired}>
         <FormLabel cursor="pointer">{label}</FormLabel>
       </FormControl>
-      {answer && <FontAwesomeIcon opacity="0.5" color="green" icon={faCheckCircle} />}
+      {isNotNullOrUndefinedOrEmpty(checked) && (
+        <FontAwesomeIcon opacity="0.5" color="green" icon={faCheckCircle} />
+      )}
     </HStack>
   )
 }


### PR DESCRIPTION
The validation tick was showing as long as `answer` was not falsy, which resulted in the checkbox always showing the validation tick. Also, the colour scheme meant you could not see the box was checked. Both of these have been resolved