### PR TITLE
10.3.0 LOJ-596 - Constrained rich text box to ask width

### DIFF
--- a/src/app/DTT/rich_text/index.js
+++ b/src/app/DTT/rich_text/index.js
@@ -176,7 +176,7 @@ const Write = ({
 
       <Box
         test-id={questionCode}
-        w="full"
+        w="24rem"
         border="1px"
         borderColor={fieldBorderColor}
         borderRadius={borderRadius}


### PR DESCRIPTION
When the rich text field component is not constrained, it widens the parent to the lengths of its content as if it were a single line.
Adding an arbitrary length causes the field's text overflow to behave correctly