### PR TITLE
Test IDs for select objects, signature, camera

### DIFF
--- a/src/app/DTT/select/index.js
+++ b/src/app/DTT/select/index.js
@@ -136,7 +136,11 @@ const Write = ({
     newValue ? setIsFocused(true) : setIsFocused(false)
     onSendAnswer(prepareValueForSendingAnswer(newValue))
   }
-
+  const formatOptionLabel = ({ label, value }) => (
+    <div test-id={`${questionCode}-${value}`}>
+      <Text>{label}</Text>
+    </div>
+  )
   // the backend accepts array only when sending dropdown values regardless of multi or single select
   const prepareValueForSendingAnswer = value =>
     value && Array.isArray(value) && value.map(i => i.value)
@@ -167,6 +171,7 @@ const Write = ({
         useBasicStyles
         isMulti={isMulti}
         options={options}
+        formatOptionLabel={formatOptionLabel}
         onChange={onChange}
         onInputChange={value => {
           setInputValue(value)

--- a/src/app/DTT/select/index.js
+++ b/src/app/DTT/select/index.js
@@ -137,9 +137,7 @@ const Write = ({
     onSendAnswer(prepareValueForSendingAnswer(newValue))
   }
   const formatOptionLabel = ({ label, value }) => (
-    <div test-id={`${questionCode}-${value}`}>
-      <Text>{label}</Text>
-    </div>
+    <Text test-id={`${questionCode}-${value}`}>{label}</Text>
   )
   // the backend accepts array only when sending dropdown values regardless of multi or single select
   const prepareValueForSendingAnswer = value =>

--- a/src/app/DTT/signature/index.js
+++ b/src/app/DTT/signature/index.js
@@ -53,6 +53,7 @@ const Write = ({ questionCode, data, onSendAnswer }) => {
         }}
         w="500px"
         value={text}
+        test-id={`${questionCode}-text`}
         onChange={e => setText(e.target.value)}
       />
 
@@ -68,7 +69,7 @@ const Write = ({ questionCode, data, onSendAnswer }) => {
           onClick={handleClear}
         />
         <SignatureCanvas
-          test-id={questionCode}
+          test-id={`${questionCode}-canvas`}
           ref={ref => (signatureRef.current = ref)}
           onEnd={() => onSendAnswer(signatureRef.current.toDataURL())}
           canvasProps={{

--- a/src/app/DTT/upload/Image.js
+++ b/src/app/DTT/upload/Image.js
@@ -95,6 +95,7 @@ const Write = ({
               onClick={() => setOpenSnap(true)}
               leftIcon={<FontAwesomeIcon icon={faCamera} />}
               hidden={dropzone}
+              test-id={questionCode}
               bg={!!isProductInternmatch && `${realm}.secondary`}
               color={!!isProductInternmatch && `${realm}.light`}
               _hover={{


### PR DESCRIPTION
All selections now have the test-id of `{questioncode}-{value}`


Signature text input has the test-id of `{questionCode}-text`, signature canvas input has the test-id of `{questionCode}-canvas`