### PR TITLE
Removed Url state manager

### DIFF
--- a/src/vertx/index.js
+++ b/src/vertx/index.js
@@ -8,7 +8,6 @@ import { useDispatch } from 'react-redux'
 import { newCmd, newMsg, sendMessage } from 'redux/app'
 import makeAuthInitData from './utils/make-auth-init-data'
 import createSendMessage from './utils/create-send-message'
-import urlStateManager from 'utils/url-state-manager'
 
 import { tokenFromUrl } from 'config/get-api-config'
 import { getSessionIdFromToken } from 'keycloak/get-token-from-url'
@@ -114,7 +113,7 @@ const VertxContainer = () => {
 
     onSendMessage = createSendMessage(token, onSendMsg)
 
-    urlStateManager(onSendMessage)(window.location.pathname)
+    // urlStateManager(onSendMessage)(window.location.pathname)
   }
 
   return null


### PR DESCRIPTION
The URL State manager is no longer used, and sends out an event message on program start. This event message is no longer needed, and can actually cause the backend to bug out if the ask too late. Jasper and Bryn have asked me to remove this event message and it seems the state manager is the way to do this.